### PR TITLE
Remove existing line-height style if present

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -35,10 +35,10 @@
 			onClick: function( value ) {
 				editor.focus();
 				editor.fire( 'saveSnapshot' );
-				var prevStyle = styles[ this.getValue() ];
-				if (prevStyle != undefined) editor['removeStyle']( prevStyle );
-				var style = styles[ value ];
-				if (style != prevStyle) editor['applyStyle']( style );
+				var style = styles[ this.getValue() ];
+				if (style != undefined) editor['removeStyle']( style );
+				var newStyle = styles[ value ];
+				if (newStyle != style ) editor['applyStyle']( newStyle );
 				editor.fire( 'saveSnapshot' );
 			},
 			onRender: function() {

--- a/plugin.js
+++ b/plugin.js
@@ -35,8 +35,10 @@
 			onClick: function( value ) {
 				editor.focus();
 				editor.fire( 'saveSnapshot' );
+				var prevStyle = styles[ this.getValue() ];
+				if (prevStyle != undefined) editor['removeStyle']( prevStyle );
 				var style = styles[ value ];
-				editor[ this.getValue() == value ? 'removeStyle' : 'applyStyle' ]( style );
+				if (style != prevStyle) editor['applyStyle']( style );
 				editor.fire( 'saveSnapshot' );
 			},
 			onRender: function() {


### PR DESCRIPTION
For older versions of Ckeditor (e.g. 4.7.1) the previous line styles aren't removed correctly. Instead a nested span appears.

- The line-height is set to 4

`<p><span style="line-height:4;">this is span 4</span></p>`

- Hit return, and set line-height to 2

`<p><span style="line-height:4;"><span style="line-height:2;">this should be span 2</span></span></p>`